### PR TITLE
fix configure.ac test1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ AM_CONDITIONAL([HAVE_CUDA], [test x"$cuda_enabled" = x"yes"])
 #Setup MPI Paths
 # ------------------------------------------------------------------------------
 AC_ARG_WITH([mpi],
-   [  --with-mpi=PATH    prefix where MPI is installed])
+   [  --with-mpi=PATH    prefix where MPI is installed],[],[with_mpi=${PATH}])
 
 mpi_enabled=no
 if test x"$with_mpi" != x"no" ; then


### PR DESCRIPTION
It seems that the variable "with_mpi" has to be inizialized before running the AX_MPI_OPTIONS macro. I have tested this on my pc and on the cluster and it works. This could fix the bug, although I can't figure out why it works passing PATH to with_mpi, when PATH is not the path that one can find using "whereis mpi".