### PR TITLE
FIX 1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,10 +80,12 @@ AM_CONDITIONAL([HAVE_CUDA], [test x"$cuda_enabled" = x"yes"])
 #Setup MPI Paths
 # ------------------------------------------------------------------------------
 AC_ARG_WITH([mpi],
-   [  --with-mpi=PATH    prefix where MPI is installed],[],[with_mpi=${PATH}])
+   [  --with-mpi=PATH    prefix where MPI is installed])
 
 mpi_enabled=no
-if test x"$with_mpi" != x"no" ; then
+if test x"$with_mpi" = x"no" ; then	
+	AC_MSG_ERROR([YOU MUST USE MPI COMPILER: Please do not give configure the option --without-mpi or --with-mpi=no])
+else   
     AX_MPI_OPTIONS
     if test x"$MPI_CXX" != x"none"; then
       AX_MPI_TESTS

--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ AM_CONDITIONAL([HAVE_CUDA], [test x"$cuda_enabled" = x"yes"])
 #Setup MPI Paths
 # ------------------------------------------------------------------------------
 AC_ARG_WITH([mpi],
-   [  --with-mpi=PATH    prefix where MPI is installed])
+   [  --with-mpi=PATH    prefix where MPI is installed],[],[with_mpi=${PATH}])
 
 mpi_enabled=no
 if test x"$with_mpi" != x"no" ; then

--- a/m4/ax_mpi_options.m4
+++ b/m4/ax_mpi_options.m4
@@ -7,6 +7,7 @@ MPI_CXX=none
 
 ###
 
+
 AC_ARG_WITH(mpi-compilers,
 AS_HELP_STRING([--with-mpi-compilers=DIR or --with-mpi-compilers=yes],
 [use MPI compiler (mpicxx) found in directory DIR, or in your PATH if =yes]),
@@ -56,34 +57,40 @@ if test "X${MPI_CXX}" = "Xnone" ; then
   MPI_CXX=${MY_CXX}
 fi
 
+
+
+# if the user gives configure the option --with-mpi=directory then set MPI_DIR
 AC_ARG_WITH(mpi,
 AS_HELP_STRING([--with-mpi=MPIROOT],[use MPI root directory.]),
 [
-  if test "X${withval}" = "Xno"; then :; else
-     MPI_DIR=${withval}
-     AC_MSG_CHECKING(MPI directory)
-     AC_MSG_RESULT([${MPI_DIR}])
-
-  fi
+	if test x"$with_mpi" != x"yes"; then
+	  MPI_DIR=${with_mpi}
+      AC_MSG_CHECKING(MPI directory)
+      AC_MSG_RESULT([${MPI_DIR}])
+    fi
 ]
 )
 
-AC_ARG_WITH(mpi-libs,
-AS_HELP_STRING([--with-mpi-libs="LIBS"],[MPI libraries @<:@default "-lmpi"@:>@]),
-[
-  if test "X${withval}" = "Xno"; then :; else
-    MPI_LIBS=${withval}
-    AC_MSG_CHECKING(user-defined MPI libraries)
-    AC_MSG_RESULT([${MPI_LIBS}])
+#otherwise try to find it
+if test -z "${MPI_DIR}";	then
+	# Here write the FIND script
+	# set MPI_DIR to the correct directory
+	# otherwise send error
+	
+	echo "Looking for MPI directory"
+	MPI_DIR="/usr/lib/openmpi"  #provisional
+	# AC_MSG_RESULT([${MPI_DIR}])
+	
+	if test -z "${MPI_DIR}";	then
+	  AC_MSG_ERROR([cannot find MPI directory])
+	fi
+fi
 
-  fi
-]
-)
 
 AC_ARG_WITH(mpi-incdir,
 AS_HELP_STRING([--with-mpi-incdir=DIR],[MPI include directory @<:@default MPIROOT/include@:>@]),
 [
-  if test "X${withval}" = "Xno"; then :; else
+  if test "X${withval}" != "Xno" && test "X${withval}" != "Xyes"; then
     MPI_INC="-I${withval}"
     AC_MSG_CHECKING(user-defined MPI includes)
     AC_MSG_RESULT([${MPI_INC}])
@@ -91,10 +98,15 @@ AS_HELP_STRING([--with-mpi-incdir=DIR],[MPI include directory @<:@default MPIROO
 ]
 )
 
+# set MPI_INC to the default directory if not already specified by the user
+if test -z "${MPI_INC}"; then
+  MPI_INC="-I${MPI_DIR}/include"
+fi
+
 AC_ARG_WITH(mpi-libdir,
 AS_HELP_STRING([--with-mpi-libdir=DIR],[MPI library directory @<:@default MPIROOT/lib@:>@]),
 [
-  if test "X${withval}" = "Xno"; then :; else
+  if test "X${withval}" != "Xno" && test "X${withval}" != "Xyes"; then
     MPI_LIBDIR="-L${withval}"
     AC_MSG_CHECKING(user-defined MPI library directory)
     AC_MSG_RESULT([${MPI_LIBDIR}])
@@ -102,5 +114,24 @@ AS_HELP_STRING([--with-mpi-libdir=DIR],[MPI library directory @<:@default MPIROO
   fi
 ]
 )
+
+if test -z "${MPI_LIBDIR}"; then
+  MPI_LIBDIR="-L${MPI_DIR}/lib"
+fi
+
+AC_ARG_WITH(mpi-libs,
+AS_HELP_STRING([--with-mpi-libs="LIBS"],[MPI libraries @<:@default "-lmpi"@:>@]),
+[
+  if test "X${withval}" != "Xno" && test "X${withval}" != "Xyes"; then
+    MPI_LIBS=${withval}
+    AC_MSG_CHECKING(user-defined MPI libraries)
+    AC_MSG_RESULT([${MPI_LIBS}])
+  fi
+]
+)
+
+if test -n "${MPI_LIBDIR}"; then
+  MPI_LIBS="-lmpi"
+fi
 
 ])

--- a/m4/ax_mpi_tests.m4
+++ b/m4/ax_mpi_tests.m4
@@ -7,52 +7,41 @@ AC_DEFUN([AX_MPI_TESTS],[
   dnl Test to see if MPI compilers work properly
   dnl 
 
-if test -n "${MPI_DIR}" && test -z "${MPI_INC}"; then
-  MPI_INC="-I${MPI_DIR}/include"
-fi
 
-if test -z "${MPI_INC}"; then
-  AC_LANG([C++])
-  AC_MSG_CHECKING(whether we can preprocess mpi.h)
-  AC_PREPROC_IFELSE(
-  [AC_LANG_SOURCE([[#include "mpi.h"]])],
-  [
-    AC_MSG_RESULT(yes)
-  ],[
-    AC_MSG_RESULT(no)
-    echo "---"
-    echo "Cannot find header file mpi.h."
-    echo "View the mpi options with \"configure --help\", and provide a valid MPI."
-    echo "---"
-    AC_MSG_ERROR(cannot find mpi.h)
-  ])
+# test if mpi.h is in MPI_INC
+CPPFLAGS=${MPI_INC}
+AC_LANG([C++])
+AC_MSG_CHECKING(whether we can preprocess mpi.h)
+AC_PREPROC_IFELSE(
+[AC_LANG_SOURCE([[#include "mpi.h"]])],
+[
+  AC_MSG_RESULT(yes)
+],[
+  AC_MSG_RESULT(no)
+  echo "---"
+  echo "Cannot find header file mpi.h."
+  echo "View the mpi options with \"configure --help\", and provide a valid MPI."
+  echo "---"
+  AC_MSG_ERROR(cannot find mpi.h)
+])
 
-  AC_MSG_CHECKING(whether we can compile mpi.h)
-  AC_COMPILE_IFELSE(
-  [AC_LANG_SOURCE([[#include "mpi.h"]],[[int c; char** v; MPI_Init(&c,&v);]])],
-  [
-    AC_MSG_RESULT(yes)
-    AC_DEFINE(HAVE_MPI,,[define that mpi is being used])
-  ],[
-    AC_MSG_RESULT(no)
-    echo "---"
-    echo "mpi.h has compile errors"
-    echo "View the mpi options with \"configure --help\", and provide a valid MPI."
-    echo "---"
-    AC_MSG_ERROR(invalid mpi.h)
-  ])
-fi
+AC_MSG_CHECKING(whether we can compile mpi.h)
+AC_COMPILE_IFELSE(
+[AC_LANG_SOURCE([[#include "mpi.h"]],[[int c; char** v; MPI_Init(&c,&v);]])],
+[
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(HAVE_MPI,,[define that mpi is being used])
+],[
+  AC_MSG_RESULT(no)
+  echo "---"
+  echo "mpi.h has compile errors"
+  echo "View the mpi options with \"configure --help\", and provide a valid MPI."
+  echo "---"
+  AC_MSG_ERROR(invalid mpi.h)
+])
 
 AC_SUBST([MPI_INC])
-  
-if test -n "${MPI_DIR}" && test -z "${MPI_LIBDIR}"; then
-  MPI_LIBDIR="-L${MPI_DIR}/lib"
-fi
 AC_SUBST([MPI_LIBDIR])
-
-if test -z "${MPI_LIBS}" && test -n "${MPI_LIBDIR}"; then
-  MPI_LIBS="-lmpi"
-fi
 AC_SUBST([MPI_LIBS])
 
 AC_LANG([C++])


### PR DESCRIPTION
Now configure always checks whether mpi.h can be preprocessed and compiled, even if the user gives configure the option --with-mpi.
The script that search for MPI directory has to be implemented. For the moment, set the variable  MPI in line 81 of ax_mpi_option.m4 with the right directory, or give configure the option --with-mpi.
